### PR TITLE
config: ignore CLAUDE.md files in Hugo builds

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -5,6 +5,8 @@ title: Stéphane's Blog
 baseurl: https://wirtel.be/
 copyright: Stéphane Wirtel
 defaultContentLanguage: en
+ignoreFiles:
+  - "CLAUDE\\.md$"
 services:
   googleAnalytics:
     id: G-BC0WC3PWS6


### PR DESCRIPTION
## Summary
- Add `ignoreFiles` directive to Hugo configuration to exclude CLAUDE.md files from builds

## Changes
- `config/_default/config.yaml`: Added regex pattern to ignore all CLAUDE.md files

## Context
This provides site-level protection against CLAUDE.md files being processed by Hugo, complementing the existing filter in the Obsidian migration script. CLAUDE.md files contain Claude Code configuration and should not be included in the published site.

## Test plan
- [x] Verified Hugo builds without processing CLAUDE.md files
- [x] Confirmed no CLAUDE.md references in build output