### PR TITLE
SEO improvements: canonical, og:image, twitter cards, h1 structure, 404

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -1,7 +1,7 @@
 ---
 newContentEditor: /usr/bin/nvim
 theme: ["original-ghostwriter", "hugo-shortcode-gallery"]
-title: Stéphane's Blog
+title: Stéphane Wirtel — Senior Python Consultant
 baseurl: https://wirtel.be/
 copyright: Stéphane Wirtel
 defaultContentLanguage: en
@@ -24,7 +24,7 @@ Params:
     email: stephane@wirtel.be
     title: Senior Python Expert
   dateFormat: Mon, Jan 2, 2006
-  description: About programming, karate, contributions and stuff I enjoy...
+  description: Stéphane Wirtel's blog, Senior Python Consultant. Articles about Python, Machine Learning, DevOps and karate.
   intro: true
   headline: 今日は
   opengraph: true
@@ -37,7 +37,7 @@ Params:
   linkedin: https://www.linkedin.com/in/stephanewirtel/
   readingTime: true
   readingTimeText: "Estimated reading time:"
-  site_name: "Stéphane's Blog"
+  site_name: "Stéphane Wirtel — Senior Python Consultant"
   mainSections: [post]
 Permalinks:
   post: /post/:year/:month/:day/:slug
@@ -67,6 +67,9 @@ menu:
     - name: About
       url: /page/about/
       weight: 5
+    - name: Consulting
+      url: https://mgx.io/
+      weight: 6
 
 markup:
   highlight:

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,29 @@
+{{ partial "header.html" . }}
+
+<div class="content container">
+    <div class="post">
+        <h1 class="post-title">Page introuvable</h1>
+        <p>La page que vous cherchez n'existe pas ou a été déplacée.</p>
+
+        <p><a href="{{ .Site.BaseURL }}">← Retour à l'accueil</a></p>
+
+        {{ $pages := first 5 (where .Site.RegularPages "Section" "post") }}
+        {{ with $pages }}
+        <h2>Articles récents</h2>
+        <ul>
+            {{ range . }}
+            <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+            {{ end }}
+        </ul>
+        {{ end }}
+
+        <h2>Pages utiles</h2>
+        <ul>
+            <li><a href="{{ .Site.BaseURL }}project">Projets</a></li>
+            <li><a href="{{ .Site.BaseURL }}talk">Talks</a></li>
+            <li><a href="{{ .Site.BaseURL }}page/about/">À propos</a></li>
+        </ul>
+    </div>
+</div>
+
+{{ partial "footer.html" . }}

--- a/layouts/partials/extra-in-head.html
+++ b/layouts/partials/extra-in-head.html
@@ -1,4 +1,9 @@
-<meta property="twitter:card" content="summary" />
+<link rel="canonical" href="{{ .Permalink }}">
+<meta property="twitter:card" content="summary_large_image" />
 <meta property="twitter:site" content="@{{ .Site.Params.twitterUsername }}" />
 <meta property="twitter:creator" content="@{{ .Site.Params.twitterUsername }}" />
+{{- $img := "" -}}
+{{- with .Resources.GetMatch "cover*" -}}{{- $img = .Permalink -}}{{- end -}}
+{{- if and (not $img) .Params.image -}}{{- $img = .Params.image | absURL -}}{{- end -}}
+{{- with $img }}<meta property="twitter:image" content="{{ . }}" />{{- end }}
 {{ if .IsHome }}{{ partial "jsonld-website.html" . }}{{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,37 @@
+            </div>
+        </div>
+
+        <footer class="footer">
+            <div class="container">
+                <div class="site-title-wrapper">
+                    <p class="site-title">
+                        <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
+                    </p>
+                    <a class="button-square button-jump-top js-jump-top" href="#" aria-label="Back to Top">
+                        <i class="fa fa-angle-up" aria-hidden="true"></i>
+                    </a>
+                </div>
+
+                <div class="consulting-cta">
+                    <p>Disponible pour du consulting Python &amp; AI —
+                        <a href="https://mgx.io/" rel="noopener">mgx.io</a> /
+                        <a href="mailto:stephane@wirtel.be">Contactez-moi</a>
+                    </p>
+                </div>
+
+                <p class="footer-copyright">
+                    <span>&copy; {{ .Site.Lastmod.Format "2006" }} / Powered by <a href="https://gohugo.io/">Hugo</a></span>
+                </p>
+                <p class="footer-copyright">
+                    <span><a href="https://github.com/roryg/ghostwriter">Ghostwriter theme</a> By <a href="http://jollygoodthemes.com">JollyGoodThemes</a></span>
+                    <span>/ <a href="https://github.com/jbub/ghostwriter">Ported</a> to Hugo By <a href="https://github.com/jbub">jbub</a></span>
+                </p>
+            </div>
+        </footer>
+
+        <script src="{{ .Site.BaseURL }}js/jquery-1.11.3.min.js"></script>
+        <script src="{{ .Site.BaseURL }}js/jquery.fitvids.js"></script>
+        <script src="{{ .Site.BaseURL }}js/scripts.js"></script>
+        {{ partial "extra-in-foot.html" . }}
+    </body>
+</html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="{{ or .Params.lang .Params.language .Site.Params.defaultContentLanguage "en" }}"{{ if .Site.Params.opengraph }} prefix="og: http://ogp.me/ns#"{{ end }}>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title>{{ .Title }} &middot; {{ .Site.Params.Author.name }}</title>
+        <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
+        <meta name="HandheldFriendly" content="True">
+        <meta name="MobileOptimized" content="320">
+        {{ hugo.Generator }}
+        <meta name="robots" content="index,follow">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        {{ if .Site.Params.opengraph }}{{ partial "opengraph.html" . }}{{ end }}
+        <link rel="stylesheet" href="{{ .Site.BaseURL }}dist/site.css">
+        <link rel="stylesheet" href="{{ .Site.BaseURL }}dist/syntax.css">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,600,700,300&subset=latin,cyrillic-ext,latin-ext,cyrillic">
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+        {{ if .OutputFormats.Get "RSS" }}
+            <link href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}" rel="alternate" type="application/rss+xml">
+        {{ end }}
+        {{ partial "extra-in-head.html" . }}
+        {{ partial "exponea.html" . }}
+        {{ partial "fathom.html" . }}
+        {{ partial "plausible.html" . }}
+    </head>
+    <body>
+        {{ template "_internal/google_analytics.html" . }}
+
+        <div id="wrapper">
+            <header class="site-header">
+                <div class="container">
+                    <div class="site-title-wrapper">
+                        {{ with .Site.Params.logo }}
+                            <a class="site-logo" href="{{ .Site.BaseURL }}">
+                                <img src="{{ . }}" alt="{{ .Title }}" />
+                            </a>
+                        {{ else }}
+                            <p class="site-title">
+                                <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
+                            </p>
+                        {{ end }}
+                        {{ if .Site.Params.rss }}
+                            <a class="button-square" href="{{ .Site.BaseURL }}index.xml" aria-label="RSS"><i class="fa fa-rss" aria-hidden="true"></i></a>
+                        {{ end }}
+                        {{ with .Site.Params.twitter }}
+                            <a class="button-square button-social hint--top" data-hint="Twitter" aria-label="Twitter" href="{{ . }}" rel="me" >
+                                <i class="fa fa-twitter" aria-hidden="true"></i>
+                            </a>
+                        {{ end }}
+                        {{ with .Site.Params.facebook }}
+                            <a class="button-square button-social hint--top" data-hint="Facebook" aria-label="Facebook" href="{{ . }}" rel="me">
+                                <i class="fa fa-facebook" aria-hidden="true"></i>
+                            </a>
+                        {{ end }}
+                        {{ with .Site.Params.gitlab }}
+                            <a class="button-square button-social hint--top" data-hint="Gitlab" aria-label="Gitlab" href="{{ . }}" rel="me">
+                                <i class="fa fa-gitlab" aria-hidden="true"></i>
+                            </a>
+                        {{ end }}
+                        {{ with .Site.Params.github }}
+                            <a class="button-square button-social hint--top" data-hint="Github" aria-label="Github" href="{{ . }}" rel="me">
+                                <i class="fa fa-github-alt" aria-hidden="true"></i>
+                            </a>
+                        {{ end }}
+                        {{ with .Site.Params.stackoverflow }}
+                            <a class="button-square button-social hint--top" data-hint="Stack Overflow" aria-label="Stack Overflow" href="{{ . }}" rel="me">
+                                <i class="fa fa-stack-overflow" aria-hidden="true"></i>
+                            </a>
+                        {{ end }}
+                        {{ with .Site.Params.linkedin }}
+                            <a class="button-square button-social hint--top" data-hint="LinkedIn" aria-label="LinkedIn" href="{{ . }}" rel="me">
+                                <i class="fa fa-linkedin" aria-hidden="true"></i>
+                            </a>
+                        {{ end }}
+                        {{ with .Site.Params.email }}
+                            <a class="button-square button-social hint--top" data-hint="Email" aria-label="Send an Email" href="mailto:{{ . }}">
+                                <i class="fa fa-envelope" aria-hidden="true"></i>
+                            </a>
+                        {{ end }}
+                    </div>
+
+                    <ul class="site-nav">
+                        {{ partial "navigation.html" . }}
+                    </ul>
+                </div>
+            </header>
+
+            <div id="container">

--- a/layouts/partials/intro.html
+++ b/layouts/partials/intro.html
@@ -1,0 +1,7 @@
+{{ if .Site.Params.intro }}
+<header class="post-header">
+    <p class="site-headline" aria-hidden="true">{{ .Site.Params.headline }}</p>
+    <h1 class="site-tagline">{{ .Site.Title }}</h1>
+    <p>{{ .Site.Params.description }}</p>
+</header>
+{{ end }}

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -17,8 +17,16 @@
     content="{{ . }}"
 />{{ end }}
 <meta property="og:url" content="{{ .Permalink }}" />
-{{ $parentScope := . }} {{- with .Params.images }} {{- range first 6 . }} {{
-$url := delimit (slice $parentScope.Permalink .) "/" | absURL }}
+{{- $img := "" -}}
+{{- with .Resources.GetMatch "cover*" -}}{{- $img = .Permalink -}}{{- end -}}
+{{- if and (not $img) .Params.image -}}{{- $img = (.Params.image | absURL) -}}{{- end -}}
+{{- if $img }}
+<meta property="og:image" content="{{ $img }}" />
+<meta property="og:image:secure_url" content="{{ $img }}" />
+{{- else -}}
+{{- $parentScope := . -}}{{- with .Params.images -}}{{- range first 6 . -}}
+{{- $url := delimit (slice $parentScope.Permalink .) "/" | absURL }}
 <meta property="og:image" content="{{ $url }}" />
 <meta property="og:image:secure_url" content="{{ $url }}" />
-{{- end }} {{- end }}
+{{- end -}}{{- end -}}
+{{- end }}


### PR DESCRIPTION
## Summary

- **config**: site title → `Stéphane Wirtel — Senior Python Consultant`, description et site_name mis à jour, ajout menu Consulting
- **extra-in-head.html**: ajout `<link rel="canonical">`, upgrade Twitter card `summary_large_image`, `twitter:image` depuis page bundle ou `.Params.image`
- **opengraph.html**: fix `og:image` — priorité page bundle `cover*`, puis `.Params.image`, fallback sur `.Params.images`
- **header.html**: override thème — attribut `lang` dynamique depuis frontmatter, `<h1>` → `<p>` pour éviter les H1 multiples
- **footer.html**: override thème — `<h1>` → `<p>`, ajout CTA consulting avant le copyright
- **intro.html**: override thème — headline japonais en `<p aria-hidden>`, titre du site en `<h1>` unique SEO
- **404.html**: page 404 personnalisée avec articles récents et liens de navigation

## Test plan

- [ ] Accueil : un seul `<h1>` dans le source (site tagline)
- [ ] Article : `lang="fr"` ou `"en"` selon frontmatter, `<link rel="canonical">` présent
- [ ] `og:image` et `twitter:image` présents sur les posts avec `cover.jpg`
- [ ] Footer : CTA consulting visible, pas de `<h1>`
- [ ] `/nonexistent` → page 404 personnalisée
- [ ] Valider JSON-LD sur https://search.google.com/test/rich-results

🤖 Generated with [Claude Code](https://claude.com/claude-code)