### PR TITLE
Upgrade Hugo to 0.157.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,9 @@
 publish = "public"
 command = "hugo --gc --minify"
 
-[context.production.environment]
+[build.environment]
 HUGO_VERSION = "0.157.0"
+
+[context.production.environment]
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,6 @@ publish = "public"
 command = "hugo --gc --minify"
 
 [context.production.environment]
-HUGO_VERSION = "0.152.2"
+HUGO_VERSION = "0.157.0"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"


### PR DESCRIPTION
## Summary

- Bump `HUGO_VERSION` from `0.152.2` to `0.157.0` (latest)

> Depends on #16. Merge #16 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)