### PR TITLE
feat: add Mermaid diagram support

### DIFF
--- a/layouts/partials/extra-in-foot.html
+++ b/layouts/partials/extra-in-foot.html
@@ -1,0 +1,13 @@
+{{ if strings.Contains .Content "class=\"language-mermaid\"" }}
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: false, theme: 'default' });
+  document.querySelectorAll('code.language-mermaid').forEach(function(el) {
+    var container = document.createElement('div');
+    container.className = 'mermaid';
+    container.textContent = el.textContent;
+    el.parentElement.replaceWith(container);
+  });
+  await mermaid.run();
+</script>
+{{ end }}


### PR DESCRIPTION
## Summary

- Adds `layouts/partials/extra-in-foot.html` overriding the empty theme partial
- Loads Mermaid.js v11 via CDN (`esm.min.mjs`) conditionally, only on pages containing a `mermaid` fenced code block
- Replaces Hugo-generated `<code class="language-mermaid">` elements with `<div class="mermaid">` so diagrams render correctly

## Test plan

- [x] Visit `/post/2026/01/08/automating-tls-certificate-monitoring-github-actions-certificate-watcher-slack/` and verify the flowchart renders
- [x] Verify Mermaid script is NOT loaded on pages without mermaid blocks