### PR TITLE
fix: add alt attribute to featured images and fix JSON-LD image URL

### DIFF
--- a/layouts/partials/jsonld-blogposting.html
+++ b/layouts/partials/jsonld-blogposting.html
@@ -34,7 +34,15 @@
 {{- end -}}
 {{- $img := "" -}}
 {{- with .Resources.GetMatch "cover*" -}}{{- $img = .Permalink -}}{{- end -}}
-{{- if and (not $img) .Params.image -}}{{- $img = (.Params.image | absURL) -}}{{- end -}}
+{{- if not $img -}}
+  {{- with .Params.image -}}
+    {{- with $.Resources.GetMatch . -}}
+      {{- $img = .Permalink -}}
+    {{- else -}}
+      {{- $img = (. | absURL) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 {{- with $img -}}
   {{- $data = merge $data (dict "image" $img) -}}
 {{- end -}}

--- a/layouts/partials/post-content.html
+++ b/layouts/partials/post-content.html
@@ -1,0 +1,7 @@
+<div class="post-content clearfix" itemprop="articleBody">
+    {{ with .Params.Image }}
+        <img class="post-featured-image" src="{{ . }}" alt="{{ $.Title }}">
+    {{ end }}
+
+    {{ .Content }}
+</div>


### PR DESCRIPTION
## Problèmes corrigés

- **Alt manquant sur les images de couverture** : les `<img class="post-featured-image">` n'avaient pas d'attribut `alt`. Override du partial `post-content.html` du thème avec `alt="{{ $.Title }}"`.
- **URL image JSON-LD incorrecte** : dans `jsonld-blogposting.html`, le fallback `.Params.image | absURL` résolvait vers la racine du site. Remplacé par `.Resources.GetMatch .Params.image` (page bundle) avec fallback `absURL`.

## Test plan
- [x] Vérifier `<img ... alt="Automating TLS Certificate Monitoring...">` sur un post avec image de couverture
- [x] Vérifier que `"image"` dans le JSON-LD BlogPosting pointe vers l'URL correcte du post (pas la racine)
- [ ] Valider avec Rich Results Test en prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)