### PR TITLE
fix: add og:image fallback and update About page H1

### DIFF
--- a/content/page/about/index.md
+++ b/content/page/about/index.md
@@ -1,5 +1,5 @@
 ---
-title: "About"
+title: "À propos de Stéphane Wirtel"
 date: "2016-11-11T14:39:12"
 author: "Stéphane Wirtel"
 description: "Senior Python Consultant with 20+ years of experience, CPython Core Developer, PSF Fellow, and certified AI developer. Based in Charleroi, Belgium."

--- a/content/page/about/index.md
+++ b/content/page/about/index.md
@@ -1,5 +1,5 @@
 ---
-title: "À propos de Stéphane Wirtel"
+title: "About Stéphane Wirtel"
 date: "2016-11-11T14:39:12"
 author: "Stéphane Wirtel"
 description: "Senior Python Consultant with 20+ years of experience, CPython Core Developer, PSF Fellow, and certified AI developer. Based in Charleroi, Belgium."

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -4,7 +4,7 @@
     <article class="post-container">
         {{ partial "page-header.html" . }}
 
-        {{ if or (eq .Title "About") (hasPrefix .Title "About") (hasPrefix .Title "À propos") }}{{ partial "jsonld-person.html" . }}{{ end }}
+        {{ if or (eq .Title "About") (hasPrefix .Title "About") (hasPrefix .Title "About") }}{{ partial "jsonld-person.html" . }}{{ end }}
 
         {{ partial "page-content.html" . }}
     </article>

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -4,7 +4,7 @@
     <article class="post-container">
         {{ partial "page-header.html" . }}
 
-        {{ if or (eq .Title "About") (hasPrefix .Title "About") }}{{ partial "jsonld-person.html" . }}{{ end }}
+        {{ if or (eq .Title "About") (hasPrefix .Title "About") (hasPrefix .Title "À propos") }}{{ partial "jsonld-person.html" . }}{{ end }}
 
         {{ partial "page-content.html" . }}
     </article>

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -30,7 +30,12 @@
 {{- $url := delimit (slice $parentScope.Permalink .) "/" | absURL }}
 <meta property="og:image" content="{{ $url }}" />
 <meta property="og:image:secure_url" content="{{ $url }}" />
-{{- end -}}{{- end -}}
+{{- end -}}{{- else -}}
+{{- with resources.Get "logo.png" -}}{{- $logo512 := .Resize "512x512" }}
+<meta property="og:image" content="{{ $logo512.Permalink }}" />
+<meta property="og:image:secure_url" content="{{ $logo512.Permalink }}" />
+{{- end -}}
+{{- end -}}
 {{- end }}
 <meta name="twitter:title" content="{{ .Title }}" />
 <meta name="twitter:description" content="{{ $desc }}" />


### PR DESCRIPTION
## Changements

### og:image fallback sur la homepage
`layouts/partials/opengraph.html` : ajout d'un fallback sur le logo du site quand aucune image de couverture n'est définie. La homepage et les pages sans image affichent désormais une image lors du partage sur LinkedIn/Twitter/Slack.

### About page H1
`content/page/about/index.md` : `title: "About"` → `title: "À propos de Stéphane Wirtel"` pour un H1 plus descriptif et SEO-friendly.
`layouts/page/single.html` : condition mise à jour pour que le JSON-LD Person soit toujours injecté sur la page About (gère le nouveau titre français).

### Note
Le titre de la homepage (`Stéphane Wirtel — Senior Python Consultant`) était déjà correct dans `config.yaml` — aucun changement nécessaire.

## Test plan
- [ ] Partager la homepage sur LinkedIn/Slack et vérifier qu'une image apparaît
- [ ] Vérifier H1 = "À propos de Stéphane Wirtel" sur `/page/about/`
- [ ] Vérifier que le JSON-LD Person est toujours présent sur la page About

🤖 Generated with [Claude Code](https://claude.com/claude-code)