### PR TITLE
perf: add lazy loading to images

### DIFF
--- a/content/page/about/index.md
+++ b/content/page/about/index.md
@@ -8,7 +8,7 @@ description: "Senior Python Consultant with 20+ years of experience, CPython Cor
 ## Hi, I'm Stéphane
 
 <div style="display:flex; align-items:center; gap:24px; margin-bottom:24px;">
-  <img src="https://github.com/matrixise.png" alt="Stéphane Wirtel" style="width:150px; height:150px; border-radius:50%; object-fit:cover; flex-shrink:0;">
+  <img src="https://github.com/matrixise.png" alt="Stéphane Wirtel" loading="eager" style="width:150px; height:150px; border-radius:50%; object-fit:cover; flex-shrink:0;">
   <div>
 
 I'm a **Senior Python Consultant** with over 20 years of experience building software, contributing to open source, and helping organisations adopt Python at scale. I'm based in **Charleroi, Belgium**, and I operate through my consulting company, [Mgx.io SRL](https://mgx.io/).

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -54,7 +54,7 @@
                     <div class="site-title-wrapper">
                         {{ with .Site.Params.logo }}
                             <a class="site-logo" href="{{ .Site.BaseURL }}">
-                                <img src="{{ . }}" alt="{{ .Title }}" />
+                                <img src="{{ . }}" alt="{{ .Title }}" loading="eager" />
                             </a>
                         {{ else }}
                             <p class="site-title">

--- a/layouts/partials/post-stub.html
+++ b/layouts/partials/post-stub.html
@@ -19,7 +19,7 @@
         {{ end }}
         <div style="display:flex; align-items:flex-start; gap:16px;">
             {{ if $imgSrc }}
-                <img src="{{ $imgSrc }}" alt="{{ .Title }}" style="width:80px; height:80px; object-fit:cover; flex-shrink:0; margin:0; border-radius:3px;">
+                <img src="{{ $imgSrc }}" alt="{{ .Title }}" loading="lazy" style="width:80px; height:80px; object-fit:cover; flex-shrink:0; margin:0; border-radius:3px;">
             {{ end }}
             <div style="min-width:0;">
                 <h4 class="post-stub-title">{{ .Title }}</h4>

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -2,6 +2,6 @@
 
 {{ range $res := .Page.Resources.ByType "image" }}
     {{ if eq $name $res.Name }}
-        <img src="{{ $res.Permalink }}"/>
+        <img src="{{ $res.Permalink }}" loading="lazy"/>
     {{ end }}
 {{ end }}


### PR DESCRIPTION
## Changements

Ajout de `loading="lazy"` sur les images below-the-fold et `loading="eager"` sur les images above-the-fold.

| Fichier | Changement |
|---------|-----------|
| `layouts/shortcodes/image.html` | `loading="lazy"` sur le shortcode `{{< image >}}` |
| `layouts/partials/post-stub.html` | `loading="lazy"` sur les thumbnails de la liste des posts |
| `layouts/partials/header.html` | `loading="eager"` sur le logo (above-the-fold) |
| `content/page/about/index.md` | `loading="eager"` sur la photo de profil (above-the-fold) |

## Impact

Améliore le LCP (Largest Contentful Paint) et réduit la bande passante initiale sur les pages avec beaucoup d'images.

## Test plan
- [x] Vérifier `loading="lazy"` sur les images de la liste des posts (homepage)
- [x] Vérifier `loading="eager"` sur le logo dans le header
- [x] Vérifier `loading="eager"` sur la photo de profil sur `/page/about/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)