### PR TITLE
feat: add BreadcrumbList schema to posts, pages, talks and projects

### DIFF
--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -5,6 +5,7 @@
         {{ partial "page-header.html" . }}
 
         {{ if or (eq .Title "About") (hasPrefix .Title "About") }}{{ partial "jsonld-person.html" . }}{{ end }}
+        {{ partial "jsonld-breadcrumb.html" . }}
 
         {{ partial "page-content.html" . }}
     </article>

--- a/layouts/partials/jsonld-breadcrumb.html
+++ b/layouts/partials/jsonld-breadcrumb.html
@@ -10,10 +10,6 @@
   {{- $blog := dict "@type" "ListItem" "position" 2 "name" "Blog" "item" (printf "%spost/" $baseURL) -}}
   {{- $post := dict "@type" "ListItem" "position" 3 "name" (.Title | markdownify | plainify) "item" .Permalink -}}
   {{- $items = $items | append $blog | append $post -}}
-{{- else if eq .Kind "page" -}}
-  {{- /* Static page: Home > [Title] */ -}}
-  {{- $page := dict "@type" "ListItem" "position" 2 "name" (.Title | markdownify | plainify) "item" .Permalink -}}
-  {{- $items = $items | append $page -}}
 {{- else if .Section -}}
   {{- /* talk, project, position, etc.: Home > [Section] > [Title] */ -}}
   {{- $sectionTitle := .Section | humanize | title -}}
@@ -21,6 +17,10 @@
   {{- $sectionItem := dict "@type" "ListItem" "position" 2 "name" $sectionTitle "item" $sectionURL -}}
   {{- $leaf := dict "@type" "ListItem" "position" 3 "name" (.Title | markdownify | plainify) "item" .Permalink -}}
   {{- $items = $items | append $sectionItem | append $leaf -}}
+{{- else if eq .Kind "page" -}}
+  {{- /* Static page without section (About, Search…): Home > [Title] */ -}}
+  {{- $page := dict "@type" "ListItem" "position" 2 "name" (.Title | markdownify | plainify) "item" .Permalink -}}
+  {{- $items = $items | append $page -}}
 {{- end -}}
 
 {{- $data := dict

--- a/layouts/partials/jsonld-breadcrumb.html
+++ b/layouts/partials/jsonld-breadcrumb.html
@@ -1,0 +1,32 @@
+{{- $baseURL := .Site.BaseURL -}}
+{{- $items := slice -}}
+
+{{- /* Item 1: Home (always present) */ -}}
+{{- $home := dict "@type" "ListItem" "position" 1 "name" "Home" "item" $baseURL -}}
+{{- $items = $items | append $home -}}
+
+{{- if eq .Section "post" -}}
+  {{- /* Post: Home > Blog > [Title] */ -}}
+  {{- $blog := dict "@type" "ListItem" "position" 2 "name" "Blog" "item" (printf "%spost/" $baseURL) -}}
+  {{- $post := dict "@type" "ListItem" "position" 3 "name" (.Title | markdownify | plainify) "item" .Permalink -}}
+  {{- $items = $items | append $blog | append $post -}}
+{{- else if eq .Kind "page" -}}
+  {{- /* Static page: Home > [Title] */ -}}
+  {{- $page := dict "@type" "ListItem" "position" 2 "name" (.Title | markdownify | plainify) "item" .Permalink -}}
+  {{- $items = $items | append $page -}}
+{{- else if .Section -}}
+  {{- /* talk, project, position, etc.: Home > [Section] > [Title] */ -}}
+  {{- $sectionTitle := .Section | humanize | title -}}
+  {{- $sectionURL := printf "%s%s/" $baseURL .Section -}}
+  {{- $sectionItem := dict "@type" "ListItem" "position" 2 "name" $sectionTitle "item" $sectionURL -}}
+  {{- $leaf := dict "@type" "ListItem" "position" 3 "name" (.Title | markdownify | plainify) "item" .Permalink -}}
+  {{- $items = $items | append $sectionItem | append $leaf -}}
+{{- end -}}
+
+{{- $data := dict
+  "@context" "https://schema.org"
+  "@type" "BreadcrumbList"
+  "itemListElement" $items
+-}}
+{{- $json := $data | jsonify (dict "indent" "  ") -}}
+{{- printf "<script type=\"application/ld+json\">%s</script>" $json | safeHTML }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -3,6 +3,7 @@
 <div class="container">
     <article class="post-container">
         {{ partial "jsonld-blogposting.html" . }}
+        {{ partial "jsonld-breadcrumb.html" . }}
 
         {{ partial "post-header.html" . }}
 

--- a/layouts/project/single.html
+++ b/layouts/project/single.html
@@ -2,6 +2,8 @@
 
 <div class="container">
     <article class="post-container" itemscope="" itemtype="http://schema.org/BlogPosting">
+        {{ partial "jsonld-breadcrumb.html" . }}
+
         {{ partial "post-header.html" . }}
 
         {{ partial "post-content.html" . }}

--- a/layouts/talk/single.html
+++ b/layouts/talk/single.html
@@ -2,6 +2,8 @@
 
 <div class="container">
     <article class="post-container">
+        {{ partial "jsonld-breadcrumb.html" . }}
+
         {{ partial "page-header.html" . }}
 
         {{ partial "page-content.html" . }}


### PR DESCRIPTION
## Changements

### Nouveau partial
`layouts/partials/jsonld-breadcrumb.html` — génère un JSON-LD `BreadcrumbList` adapté selon le type de page :
- **Posts** : Home > Blog > [Titre du post] (3 niveaux)
- **Pages statiques** : Home > [Titre] (2 niveaux)
- **Talks / Projects / Positions** : Home > [Section] > [Titre] (3 niveaux)

### Layouts mis à jour
- `layouts/post/single.html`
- `layouts/page/single.html`
- `layouts/talk/single.html`
- `layouts/project/single.html`

## Impact SEO

Permet à Google d'afficher des breadcrumbs dans les SERPs (rich results), améliore le CTR et aide les AI engines à comprendre la hiérarchie du site.

## Test plan
- [x] Vérifier la présence du JSON-LD BreadcrumbList dans le source d'un post
- [ ] Tester avec Rich Results Test de Google
- [x] Vérifier les 4 types de pages (post, page, talk, project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)