### PR TITLE
feat: add consulting CTA at the end of blog posts

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -42,6 +42,7 @@ Params:
   email: stephane@wirtel.be
   linkedin: https://www.linkedin.com/in/stephanewirtel/
   consultingURL: https://mgx.io/
+  consultingEmail: stephane.wirtel@mgx.io
   readingTime: true
   readingTimeText: "Estimated reading time:"
   site_name: "Stéphane Wirtel — Senior Python Consultant"

--- a/layouts/partials/post-consulting-cta.html
+++ b/layouts/partials/post-consulting-cta.html
@@ -1,0 +1,12 @@
+<section style="margin: 2.5rem 0; padding: 1.5rem 2rem; border-left: 4px solid #2b2b2b; background: #f9f9f9;">
+    <h3 style="margin-top: 0; font-size: 1.2rem;">Besoin d'aide sur ce sujet ?</h3>
+    <p style="margin-bottom: 1rem;">
+        Stéphane est disponible pour du consulting Python et AI.
+        20+ ans d'expérience, CPython Core Developer, PSF Fellow.
+    </p>
+    <p style="margin-bottom: 0;">
+        <a href="{{ .Site.Params.consultingURL }}" rel="noopener" style="font-weight: bold;">{{ .Site.Params.consultingURL | strings.TrimPrefix "https://" | strings.TrimSuffix "/" }}</a>
+        &nbsp;&mdash;&nbsp;
+        <a href="mailto:{{ .Site.Params.email }}">{{ .Site.Params.email }}</a>
+    </p>
+</section>

--- a/layouts/partials/post-consulting-cta.html
+++ b/layouts/partials/post-consulting-cta.html
@@ -1,8 +1,8 @@
 <section style="margin: 2.5rem 0; padding: 1.5rem 2rem; border-left: 4px solid #2b2b2b; background: #f9f9f9;">
-    <h3 style="margin-top: 0; font-size: 1.2rem;">Besoin d'aide sur ce sujet ?</h3>
+    <h3 style="margin-top: 0; font-size: 1.2rem;">Need help on this topic?</h3>
     <p style="margin-bottom: 1rem;">
-        Stéphane est disponible pour du consulting Python et AI.
-        20+ ans d'expérience, CPython Core Developer, PSF Fellow.
+        Stéphane is available for Python &amp; AI consulting.
+        20+ years of experience, CPython Core Developer, PSF Fellow.
     </p>
     <p style="margin-bottom: 0;">
         <a href="{{ .Site.Params.consultingURL }}" rel="noopener" style="font-weight: bold;">{{ .Site.Params.consultingURL | strings.TrimPrefix "https://" | strings.TrimSuffix "/" }}</a>

--- a/layouts/partials/post-consulting-cta.html
+++ b/layouts/partials/post-consulting-cta.html
@@ -7,6 +7,6 @@
     <p style="margin-bottom: 0;">
         <a href="{{ .Site.Params.consultingURL }}" rel="noopener" style="font-weight: bold;">{{ .Site.Params.consultingURL | strings.TrimPrefix "https://" | strings.TrimSuffix "/" }}</a>
         &nbsp;&mdash;&nbsp;
-        <a href="mailto:{{ .Site.Params.email }}">{{ .Site.Params.email }}</a>
+        <a href="mailto:{{ .Site.Params.consultingEmail }}">{{ .Site.Params.consultingEmail }}</a>
     </p>
 </section>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -10,6 +10,8 @@
 
         {{ partial "post-footer.html" . }}
 
+        {{ partial "post-consulting-cta.html" . }}
+
         {{ partial "related-posts.html" . }}
 
         {{ partial "comments.html" . }}


### PR DESCRIPTION
## Changements

### Nouveau partial
`layouts/partials/post-consulting-cta.html` — bloc CTA consulting affiché en fin d'article, avec :
- Titre "Besoin d'aide sur ce sujet ?"
- Pitch court (20+ ans d'expérience, CPython Core Developer, PSF Fellow)
- Liens vers `{{ .Site.Params.consultingURL }}` (mgx.io) et `{{ .Site.Params.email }}`
- Stylé avec CSS inline cohérent avec le footer existant (bordure gauche)

### Layout mis à jour
`layouts/post/single.html` — inclusion du partial entre `post-footer.html` et `related-posts.html`.

## Impact

Capture les visiteurs qualifiés qui viennent de lire un article technique approfondi, au moment où leur intérêt est maximal.

## Test plan
- [x] Vérifier l'affichage du CTA sur un post (ex: `/post/2026/01/08/automating-tls-certificate-monitoring…/`)
- [x] Vérifier que les liens mgx.io et email fonctionnent
- [x] Vérifier le rendu mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)