### PR TITLE
feat: enrich Person schema with knowsAbout and description for GEO

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -29,6 +29,19 @@ Params:
     name: Stéphane Wirtel
     email: stephane@wirtel.be
     title: Senior Python Expert
+    description: "CPython Core Developer, Python Software Foundation Fellow, and Senior Python Consultant with 20+ years of experience. Specializes in Python, AI, and open source."
+    knowsAbout:
+      - "Python"
+      - "CPython"
+      - "Artificial Intelligence"
+      - "Machine Learning"
+      - "Open Source Software"
+      - "DevOps"
+      - "Software Architecture"
+      - "PostgreSQL"
+      - "Django"
+      - "FastAPI"
+      - "Blockchain"
   dateFormat: Mon, Jan 2, 2006
   description: Articles about Python, AI & Open Source
   intro: true

--- a/layouts/partials/jsonld-person.html
+++ b/layouts/partials/jsonld-person.html
@@ -3,12 +3,26 @@
   "@type" "Person"
   "name" .Site.Params.Author.name
   "jobTitle" "Senior Python Consultant"
+  "description" .Site.Params.Author.description
   "email" .Site.Params.email
   "url" (printf "%spage/about/" .Site.BaseURL)
   "sameAs" (slice
     "https://github.com/matrixise"
     "https://www.linkedin.com/in/stephanewirtel/"
     "https://mgx.io/"
+    "https://twitter.com/matrixise"
+  )
+  "knowsAbout" .Site.Params.Author.knowsAbout
+  "memberOf" (slice
+    (dict
+      "@type" "Organization"
+      "name" "Python Software Foundation"
+      "url" "https://www.python.org/psf/"
+    )
+  )
+  "award" (slice
+    "PSF Community Service Award 2016"
+    "Python Software Foundation Fellow since 2013"
   )
   | jsonify (dict "indent" "  ") -}}
 {{- printf "<script type=\"application/ld+json\">%s</script>" $json | safeHTML }}

--- a/layouts/partials/jsonld-person.html
+++ b/layouts/partials/jsonld-person.html
@@ -21,7 +21,7 @@
     )
   )
   "award" (slice
-    "PSF Community Service Award 2016"
+    "Python Software Foundation Community Service Award 2016"
     "Python Software Foundation Fellow since 2013"
   )
   | jsonify (dict "indent" "  ") -}}


### PR DESCRIPTION
## Changements

### `layouts/partials/jsonld-person.html`
Schema `Person` enrichi avec :
- `description` — bio d'autorité (CPython Core Dev, PSF Fellow, 20+ ans)
- `knowsAbout` — liste de 11 domaines (Python, CPython, AI, ML, DevOps, Django, FastAPI…)
- `memberOf` — Python Software Foundation avec URL
- `award` — PSF Community Service Award + PSF Fellow
- Twitter/X ajouté dans `sameAs`

### `config/_default/config.yaml`
Ajout de deux nouveaux paramètres sous `Params.Author` :
- `description` : bio courte
- `knowsAbout` : liste des domaines d'expertise

## Impact GEO

Permet aux LLMs de comprendre qui est Stéphane et dans quels domaines il fait autorité. Augmente la probabilité d'être cité sur des requêtes Python/AI/Open Source.

## Test plan
- [x] Vérifier le JSON-LD Person sur `/page/about/`
- [x] Valider avec `validator.schema.org`
- [x] Vérifier que `knowsAbout` et `memberOf` sont présents

🤖 Generated with [Claude Code](https://claude.com/claude-code)