### PR TITLE
fix: correct About breadcrumb levels and add alt to project images

### DIFF
--- a/layouts/partials/jsonld-breadcrumb.html
+++ b/layouts/partials/jsonld-breadcrumb.html
@@ -10,7 +10,7 @@
   {{- $blog := dict "@type" "ListItem" "position" 2 "name" "Blog" "item" (printf "%spost/" $baseURL) -}}
   {{- $post := dict "@type" "ListItem" "position" 3 "name" (.Title | markdownify | plainify) "item" .Permalink -}}
   {{- $items = $items | append $blog | append $post -}}
-{{- else if .Section -}}
+{{- else if and .Section (ne .Section "page") -}}
   {{- /* talk, project, position, etc.: Home > [Section] > [Title] */ -}}
   {{- $sectionTitle := .Section | humanize | title -}}
   {{- $sectionURL := printf "%s%s/" $baseURL .Section -}}

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -2,6 +2,6 @@
 
 {{ range $res := .Page.Resources.ByType "image" }}
     {{ if eq $name $res.Name }}
-        <img src="{{ $res.Permalink }}" loading="lazy"/>
+        <img src="{{ $res.Permalink }}" alt="{{ $res.Name }}" loading="lazy"/>
     {{ end }}
 {{ end }}


### PR DESCRIPTION
## Changements

### 1. BreadcrumbList — niveau "Page" parasite sur la page About

`layouts/partials/jsonld-breadcrumb.html` : la condition `else if .Section` capturait toutes les pages avec une section non vide, y compris `/page/about/` (`.Section = "page"`), produisant 3 niveaux erronés `Home > Page > About Stéphane Wirtel`.

Fix : `else if and .Section (ne .Section "page")` — les pages de la section "page" tombent maintenant dans la branche 2 niveaux `Home > About Stéphane Wirtel`.

### 2. Alt manquant dans le shortcode `{{< image >}}`

`layouts/shortcodes/image.html` : attribut `alt="{{ $res.Name }}"` ajouté sur le `<img>`. Couvre les images insérées via shortcode dans les pages projet et posts.

## Test plan
- [x] Vérifier BreadcrumbList sur `/page/about/` → 2 niveaux (Home > About Stéphane Wirtel)
- [x] Vérifier BreadcrumbList sur un projet → toujours 3 niveaux (Home > Project > Titre)
- [x] Inspecter une image rendue via `{{< image >}}` → `alt` présent

🤖 Generated with [Claude Code](https://claude.com/claude-code)