### PR TITLE
fix: resize og:image to 1200px and add width/height meta tags

### DIFF
--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -19,23 +19,31 @@
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
 {{ with .Site.Params.site_name }}<meta property="og:site_name" content="{{ . }}" />{{ end }}
 <meta property="og:url" content="{{ .Permalink }}" />
-{{- $img := "" -}}
-{{- with .Resources.GetMatch "cover*" -}}{{- $img = .Permalink -}}{{- end -}}
-{{- if and (not $img) .Params.image -}}{{- $img = (.Params.image | absURL) -}}{{- end -}}
-{{- if $img }}
-<meta property="og:image" content="{{ $img }}" />
-<meta property="og:image:secure_url" content="{{ $img }}" />
+{{- $imgRes := "" -}}
+{{- with .Resources.GetMatch "cover*" -}}{{- $imgRes = . -}}{{- end -}}
+{{- if $imgRes -}}
+  {{- $imgResized := $imgRes.Resize "1200x" -}}
+  <meta property="og:image" content="{{ $imgResized.Permalink }}" />
+  <meta property="og:image:secure_url" content="{{ $imgResized.Permalink }}" />
+  <meta property="og:image:width" content="{{ $imgResized.Width }}" />
+  <meta property="og:image:height" content="{{ $imgResized.Height }}" />
+{{- else if .Params.image -}}
+  {{- $img := (.Params.image | absURL) -}}
+  <meta property="og:image" content="{{ $img }}" />
+  <meta property="og:image:secure_url" content="{{ $img }}" />
 {{- else -}}
-{{- $parentScope := . -}}{{- with .Params.images -}}{{- range first 6 . -}}
-{{- $url := delimit (slice $parentScope.Permalink .) "/" | absURL }}
-<meta property="og:image" content="{{ $url }}" />
-<meta property="og:image:secure_url" content="{{ $url }}" />
-{{- end -}}{{- else -}}
-{{- with resources.Get "logo.png" -}}{{- $logo512 := .Resize "512x512" }}
-<meta property="og:image" content="{{ $logo512.Permalink }}" />
-<meta property="og:image:secure_url" content="{{ $logo512.Permalink }}" />
-{{- end -}}
-{{- end -}}
+  {{- $parentScope := . -}}{{- with .Params.images -}}{{- range first 6 . -}}
+  {{- $url := delimit (slice $parentScope.Permalink .) "/" | absURL }}
+  <meta property="og:image" content="{{ $url }}" />
+  <meta property="og:image:secure_url" content="{{ $url }}" />
+  {{- end -}}{{- else -}}
+  {{- with resources.Get "logo.png" -}}{{- $logo1200 := .Resize "1200x630 png" }}
+  <meta property="og:image" content="{{ $logo1200.Permalink }}" />
+  <meta property="og:image:secure_url" content="{{ $logo1200.Permalink }}" />
+  <meta property="og:image:width" content="{{ $logo1200.Width }}" />
+  <meta property="og:image:height" content="{{ $logo1200.Height }}" />
+  {{- end -}}
+  {{- end -}}
 {{- end }}
 <meta name="twitter:title" content="{{ .Title }}" />
 <meta name="twitter:description" content="{{ $desc }}" />


### PR DESCRIPTION
## Problème

LinkedIn affichait les images de couverture en petite vignette (pixelisée) car :
1. L'image n'était pas redimensionnée à la largeur minimale recommandée par LinkedIn (1200px)
2. Les tags `og:image:width` et `og:image:height` étaient absents — sans dimensions explicites, LinkedIn choisit le format d'affichage "safe" (petite carte)

## Fix

`layouts/partials/opengraph.html` :
- Garde l'objet resource Hugo (au lieu du permalink seul) pour accéder aux dimensions
- Redimensionne l'image à **1200px de large** via `.Resize "1200x"` (ratio préservé)
- Ajoute `og:image:width` et `og:image:height` avec les dimensions réelles

## Résultat

```html
<meta property="og:image" content=".../cover_hu_xxx.jpg" />
<meta property="og:image:width" content="1200" />
<meta property="og:image:height" content="655" />
```

LinkedIn affichera désormais la grande carte image au lieu de la vignette.

## Test plan
- [ ] Tester sur LinkedIn Post Inspector après merge + déploiement
- [ ] Vérifier que l'image s'affiche en grande carte sur un post avec cover image
- [ ] Cliquer "Refresh" dans l'inspecteur pour invalider le cache LinkedIn

🤖 Generated with [Claude Code](https://claude.com/claude-code)