### PR TITLE
fix: crop og:image to exactly 1200x630

### DIFF
--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -22,7 +22,7 @@
 {{- $imgRes := "" -}}
 {{- with .Resources.GetMatch "cover*" -}}{{- $imgRes = . -}}{{- end -}}
 {{- if $imgRes -}}
-  {{- $imgResized := $imgRes.Resize "1200x" -}}
+  {{- $imgResized := $imgRes.Fill "1200x630" -}}
   <meta property="og:image" content="{{ $imgResized.Permalink }}" />
   <meta property="og:image:secure_url" content="{{ $imgResized.Permalink }}" />
   <meta property="og:image:width" content="{{ $imgResized.Width }}" />


### PR DESCRIPTION
## Summary

- Replace `.Resize "1200x"` with `.Fill "1200x630"` in `layouts/partials/opengraph.html`

## Problem

`.Resize "1200x"` scales the image to 1200px wide while preserving the original aspect ratio. For a typical blog image (e.g. 16:9), this results in a height of ~675px or less, which does not conform to the Open Graph specification that recommends exactly **1200×630px**.

## Fix

`.Fill "1200x630"` crops the image intelligently from the center to produce an image with exactly the right dimensions. This ensures:

- Width: always 1200px
- Height: always 630px
- Aspect ratio: ~1.91:1, matching the OG spec

Social platforms (Twitter/X, LinkedIn, Facebook) render OG images best at 1200×630px. Using `.Fill` guarantees correct dimensions regardless of the source image's original proportions.

## Test plan

- [x] Build the site locally and verify `og:image` meta tag points to a 1200×630 image
- [x] Check with a social media debugger (e.g. [opengraph.xyz](https://www.opengraph.xyz)) that the image displays correctly