### PR TITLE
feat: enrich OG and Twitter meta tags

### DIFF
--- a/layouts/partials/extra-in-head.html
+++ b/layouts/partials/extra-in-head.html
@@ -2,11 +2,19 @@
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@{{ .Site.Params.twitterUsername }}" />
 <meta name="twitter:creator" content="@{{ .Site.Params.twitterUsername }}" />
-{{- $img := "" -}}
-{{- with .Resources.GetMatch "cover*" -}}{{- $img = .Permalink -}}{{- end -}}
-{{- if and (not $img) .Params.image -}}{{- $img = .Params.image | absURL -}}{{- end -}}
-{{- with $img }}
-<meta name="twitter:image" content="{{ . }}" />{{- end }}
+{{- $twitterImg := "" -}}
+{{- with .Resources.GetMatch "cover*" -}}
+  {{- $resized := .Fill "1200x630" -}}
+  {{- $twitterImg = $resized.Permalink -}}
+{{- end -}}
+{{- if and (not $twitterImg) .Params.image -}}{{- $twitterImg = .Params.image | absURL -}}{{- end -}}
+{{- with $twitterImg }}
+<meta name="twitter:image" content="{{ . }}" />
+<meta name="twitter:image:alt" content="{{ $.Title }}" />
+{{- end }}
+{{- with .Site.Params.Author.name }}
+<meta name="author" content="{{ . }}" />
+{{- end }}
 {{ if .IsHome }}{{ partial "jsonld-website.html" . }}{{ end }}
 {{- if or (eq .Kind "term") (eq .Kind "taxonomy") -}}
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/taxonomy.css">

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -17,6 +17,18 @@
 <meta property="og:title" content="{{ .Title }}" />
 <meta property="og:description" content="{{ $desc }}" />
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
+{{- if .IsPage }}
+<meta property="article:published_time" content="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}" />
+<meta property="article:modified_time" content="{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}" />
+{{- with .Site.Params.Author.name }}
+<meta property="article:author" content="{{ . }}" />
+{{- end }}
+{{- with .Params.tags }}
+{{- range . }}
+<meta property="article:tag" content="{{ . }}" />
+{{- end }}
+{{- end }}
+{{- end }}
 {{ with .Site.Params.site_name }}<meta property="og:site_name" content="{{ . }}" />{{ end }}
 <meta property="og:url" content="{{ .Permalink }}" />
 {{- $imgRes := "" -}}
@@ -27,21 +39,25 @@
   <meta property="og:image:secure_url" content="{{ $imgResized.Permalink }}" />
   <meta property="og:image:width" content="{{ $imgResized.Width }}" />
   <meta property="og:image:height" content="{{ $imgResized.Height }}" />
+  <meta property="og:image:alt" content="{{ $.Title }}" />
 {{- else if .Params.image -}}
   {{- $img := (.Params.image | absURL) -}}
   <meta property="og:image" content="{{ $img }}" />
   <meta property="og:image:secure_url" content="{{ $img }}" />
+  <meta property="og:image:alt" content="{{ .Title }}" />
 {{- else -}}
   {{- $parentScope := . -}}{{- with .Params.images -}}{{- range first 6 . -}}
   {{- $url := delimit (slice $parentScope.Permalink .) "/" | absURL }}
   <meta property="og:image" content="{{ $url }}" />
   <meta property="og:image:secure_url" content="{{ $url }}" />
+  <meta property="og:image:alt" content="{{ $parentScope.Title }}" />
   {{- end -}}{{- else -}}
   {{- with resources.Get "logo.png" -}}{{- $logo1200 := .Resize "1200x630 png" }}
   <meta property="og:image" content="{{ $logo1200.Permalink }}" />
   <meta property="og:image:secure_url" content="{{ $logo1200.Permalink }}" />
   <meta property="og:image:width" content="{{ $logo1200.Width }}" />
   <meta property="og:image:height" content="{{ $logo1200.Height }}" />
+  <meta property="og:image:alt" content="{{ $.Title }}" />
   {{- end -}}
   {{- end -}}
 {{- end }}


### PR DESCRIPTION
## Summary

- Add `og:image:alt` after every `og:image` tag in `opengraph.html` (covers all four image code paths: cover resource, `params.image`, `params.images` loop, and logo fallback)
- Add `article:*` meta tags (`published_time`, `modified_time`, `author`, and per-tag `article:tag`) conditionally when `og:type=article` (i.e. on pages)
- Fix `twitter:image` in `extra-in-head.html` to use the `.Fill "1200x630"` resized image instead of the raw cover permalink, matching the OG image behaviour
- Add `twitter:image:alt` alongside the Twitter image tag
- Add `<meta name="author">` from `Site.Params.Author.name`

## Test plan

- [x] Build the site locally with `hugo server` and inspect the `<head>` of a blog post — verify `article:published_time`, `article:modified_time`, `article:author`, `article:tag`, `og:image:alt`, `twitter:image` (resized URL), `twitter:image:alt`, and `author` tags are present
- [x] Check a non-page (home, taxonomy) — verify `article:*` tags are absent
- [x] Validate with a social media debugger (e.g. LinkedIn Post Inspector or Twitter Card Validator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)