### PR TITLE
fix: display cover image from page bundle in articles

### DIFF
--- a/layouts/partials/post-content.html
+++ b/layouts/partials/post-content.html
@@ -1,7 +1,10 @@
 <div class="post-content clearfix" itemprop="articleBody">
-    {{ with .Params.Image }}
-        <img class="post-featured-image" src="{{ . }}" alt="{{ $.Title }}">
-    {{ end }}
+    {{- $coverImg := .Resources.GetMatch "cover*" -}}
+    {{- with $coverImg }}
+    <img class="post-featured-image" src="{{ .Permalink }}" alt="{{ $.Title }}">
+    {{- else }}{{- with $.Params.Image }}
+    <img class="post-featured-image" src="{{ . }}" alt="{{ $.Title }}">
+    {{- end }}{{- end }}
 
     {{ .Content }}
 </div>


### PR DESCRIPTION
## Summary

- The post template (`post-content.html`) only checked `params.image` (frontmatter) to display the cover image
- Cover images are stored as page bundle resources (`cover.jpg`) and were never rendered in the article body
- This was inconsistent with the OG tags which already used `.Resources.GetMatch "cover*"` correctly

## Fix

Check for a `cover*` page bundle resource first, fall back to `params.image` if absent — consistent with how `opengraph.html` already works.

## Test plan

- [x] Open an article with a `cover.jpg` bundle resource (e.g. `/post/2026/02/05/2026-certified-ai-developer/`) — image should now appear at the top of the content
- [x] Open an article with `image` in frontmatter — still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)