### PR TITLE
fix: expand homepage meta description for better SEO

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -43,7 +43,7 @@ Params:
       - "FastAPI"
       - "Blockchain"
   dateFormat: Mon, Jan 2, 2006
-  description: Articles about Python, AI & Open Source
+  description: "Personal blog of Stéphane Wirtel — CPython Core Developer, PSF Fellow, and Python community member. Writing about Python, AI, open source, and software craftsmanship."
   intro: true
   headline: 今日は
   opengraph: true


### PR DESCRIPTION
## Summary

- Expands the homepage meta description from the generic "Articles about Python, AI & Open Source" (37 chars) to a richer, keyword-optimized version (~155 chars)
- New value: *"Personal blog of Stéphane Wirtel — CPython Core Developer, PSF Fellow, and Python community member. Writing about Python, AI, open source, and software craftsmanship."*

## Test plan

- [ ] Check `<meta name="description">` on homepage
- [ ] Validate in Google Search Console preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)