### PR TITLE
perf: load Google Analytics via requestIdleCallback to improve LCP

### DIFF
--- a/layouts/partials/google-analytics.html
+++ b/layouts/partials/google-analytics.html
@@ -1,0 +1,22 @@
+{{ if eq hugo.Environment "production" }}
+{{ with .Site.Config.Services.GoogleAnalytics.ID }}
+<script>
+  function loadGA() {
+    var s = document.createElement('script');
+    s.src = 'https://www.googletagmanager.com/gtag/js?id={{ . }}';
+    s.async = true;
+    document.head.appendChild(s);
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    window.gtag = gtag;
+    gtag('js', new Date());
+    gtag('config', '{{ . }}');
+  }
+  if ('requestIdleCallback' in window) {
+    requestIdleCallback(loadGA);
+  } else {
+    setTimeout(loadGA, 2000);
+  }
+</script>
+{{ end }}
+{{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -48,7 +48,7 @@
         {{ partial "plausible.html" . }}
     </head>
     <body>
-        {{ template "_internal/google_analytics.html" . }}
+        {{ partial "google-analytics.html" . }}
 
         <div id="wrapper">
             <header class="site-header">


### PR DESCRIPTION
## Summary

- Replaces the blocking `{{ template "_internal/google_analytics.html" . }}` Hugo internal template with a custom partial that defers GA loading
- Google Analytics (`gtag.js`) is now loaded only after the browser is idle via `requestIdleCallback`, preventing it from blocking the main render thread and improving LCP
- Includes a `setTimeout(loadGA, 2000)` fallback for Safari, which does not support `requestIdleCallback`
- GA loading is still gated to the production environment only

## Why this matters

The built-in Hugo GA template injects `gtag.js` synchronously in the `<body>`, which competes with critical rendering resources. By deferring to idle time, the browser can complete the Largest Contentful Paint before spending resources on analytics.

## Test plan

- [ ] Verify GA events still fire in production by checking the GA dashboard or using the GA Debugger Chrome extension
- [ ] Run Lighthouse on production to confirm LCP improvement
- [ ] Test in Safari to ensure the `setTimeout` fallback fires analytics after 2 seconds
- [ ] Confirm GA does NOT load in development environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)